### PR TITLE
fix: 리스트의 이미지를 정사각형으로 고정

### DIFF
--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import ShapedImage from '@/components/ShapedImage';
+import Image from 'next/image';
 import Tag from '@/components/Tag';
 import { formatDate } from '@/utils';
 import { State } from '@/types';
@@ -23,7 +23,9 @@ export default function ListItem({
   return (
     <Link href={href}>
       <styles.ListBox>
-        <ShapedImage src={thumbnail} alt="썸네일" size="5rem" />
+        <styles.ImageBox>
+          <Image src={thumbnail} alt="썸네일" width={300} height={300} />
+        </styles.ImageBox>
         <styles.RightBox>
           <Tag state={state || 'UNRESOLVED'} />
           <styles.ListTitle>{title}</styles.ListTitle>

--- a/components/styles/ListItem.style.ts
+++ b/components/styles/ListItem.style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 export const ListBox = styled.div`
+  max-height: 9rem;
   margin-bottom: 1rem;
   display: flex;
   align-items: center;
@@ -8,6 +9,27 @@ export const ListBox = styled.div`
   padding: 1rem;
   box-shadow: var(--box-shadow);
   border-radius: var(--border-radius);
+`;
+
+export const ImageBox = styled.div`
+  flex-basis: 30%;
+  position: relative;
+  max-width: 7rem;
+
+  &:after {
+    display: block;
+    content: '';
+    padding-bottom: 100%;
+    max-height: 7rem;
+  }
+
+  & > img {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--border-radius);
+  }
 `;
 
 export const RightBox = styled.div`


### PR DESCRIPTION
## 📌 작업사항

- closes #90 

## 💌 참고사항
- 어제 이미지 컴포넌트 수정하고 오늘 보니까 리스트 이미지 세로가 엄청 길어졌길래 수정했습니다~~

## 📸 스크린샷
